### PR TITLE
gxl: remote: Add support for Sony SIRC 12/15/20

### DIFF
--- a/arch/arm/cpu/armv8/gxl/firmware/scp_task/scp_remote.c
+++ b/arch/arm/cpu/armv8/gxl/firmware/scp_task/scp_remote.c
@@ -7,7 +7,9 @@ enum {
 	DECODEMODE_NEC = 0,
 	DECODEMODE_DUOKAN = 1,
 	DECODEMODE_RCMM,
-	DECODEMODE_SONYSIRC,
+	DECODEMODE_SONYSIRC12,
+	DECODEMODE_SONYSIRC15,
+	DECODEMODE_SONYSIRC20,
 	DECODEMODE_SKIPLEADER,
 	DECODEMODE_MITSUBISHI,
 	DECODEMODE_THOMSON,
@@ -101,12 +103,111 @@ static const reg_remote RDECODEMODE_RC5[] = {
 	{CONFIG_END, 0}
 };
 
+static const reg_remote RDECODEMODE_SONYSIRC12[] = {
+	/* (4 +/- .5) * 600 us */
+	{ AO_MF_IR_DEC_LDR_ACTIVE, 135 << 16 | 105 << 0		    },
+	/* (1 +/- .5) * 600 us */
+	{ AO_MF_IR_DEC_LDR_IDLE,   45 << 16 | 15 << 0		    },
+	/* No repeat code */
+	{ AO_MF_IR_DEC_LDR_REPEAT, 0				    },
+	/* (2 +/- .5) * 600 us */
+	{ AO_MF_IR_DEC_BIT_0,	   75 << 16 | 45 << 0		    },
+	/*
+	 * Filter: 140 us, max frame time: (4.5 + 1.5 + 12 * 3.5) * 600 us,
+	 * base time: 20 us
+	 */
+	{ AO_MF_IR_DEC_REG0,	   7 << 28 | 1440 << 12 | (20 - 1)  },
+	/* Logic "1": (3 +/- .5) * 600 us */
+	{ AO_MF_IR_DEC_STATUS,	   1 << 30 | 105 << 20 | 75 << 10   },
+	/*
+	 * Reset the decoder as a workaround for an IP erratum causing the
+	 * repeat max frame interval in REG3 to be ignored for SIRC.
+	 */
+	{ AO_MF_IR_DEC_REG1,	   1 << 15 | (11 - 1) << 8 | 1	    },
+	/* Decoder, frame body limited to 11 bits because of IP erratum */
+	{ AO_MF_IR_DEC_REG1,	   1 << 15 | (11 - 1) << 8	    },
+	/* Check repeat time, compare frames for repeat, lsb first, Sony SIRC */
+	{ AO_MF_IR_DEC_REG2,	   1 << 12 | 1 << 11 | 0 << 8 | 0x6 },
+	{ AO_MF_IR_DEC_DURATN2,	   0				    },
+	{ AO_MF_IR_DEC_DURATN3,	   0				    },
+	/* Repeat max frame interval: 50 ms */
+	{ AO_MF_IR_DEC_REG3,	   500				    },
+	{ CONFIG_END,		   0				    }
+};
+
+static const reg_remote RDECODEMODE_SONYSIRC15[] = {
+	/* (4 +/- .5) * 600 us */
+	{ AO_MF_IR_DEC_LDR_ACTIVE, 135 << 16 | 105 << 0		    },
+	/* (1 +/- .5) * 600 us */
+	{ AO_MF_IR_DEC_LDR_IDLE,   45 << 16 | 15 << 0		    },
+	/* No repeat code */
+	{ AO_MF_IR_DEC_LDR_REPEAT, 0				    },
+	/* (2 +/- .5) * 600 us */
+	{ AO_MF_IR_DEC_BIT_0,	   75 << 16 | 45 << 0		    },
+	/*
+	 * Filter: 140 us, max frame time: (4.5 + 1.5 + 15 * 3.5) * 600 us,
+	 * base time: 20 us
+	 */
+	{ AO_MF_IR_DEC_REG0,	   7 << 28 | 1755 << 12 | (20 - 1)  },
+	/* Logic "1": (3 +/- .5) * 600 us */
+	{ AO_MF_IR_DEC_STATUS,	   1 << 30 | 105 << 20 | 75 << 10   },
+	/*
+	 * Reset the decoder as a workaround for an IP erratum causing the
+	 * repeat max frame interval in REG3 to be ignored for SIRC.
+	 */
+	{ AO_MF_IR_DEC_REG1,	   1 << 15 | (14 - 1) << 8 | 1	    },
+	/* Decoder, frame body limited to 14 bits because of IP erratum */
+	{ AO_MF_IR_DEC_REG1,	   1 << 15 | (14 - 1) << 8	    },
+	/* Check repeat time, compare frames for repeat, lsb first, Sony SIRC */
+	{ AO_MF_IR_DEC_REG2,	   1 << 12 | 1 << 11 | 0 << 8 | 0x6 },
+	{ AO_MF_IR_DEC_DURATN2,	   0				    },
+	{ AO_MF_IR_DEC_DURATN3,	   0				    },
+	/* Repeat max frame interval: 50 ms */
+	{ AO_MF_IR_DEC_REG3,	   500				    },
+	{ CONFIG_END,		   0				    }
+};
+
+static const reg_remote RDECODEMODE_SONYSIRC20[] = {
+	/* (4 +/- .5) * 600 us */
+	{ AO_MF_IR_DEC_LDR_ACTIVE, 135 << 16 | 105 << 0		    },
+	/* (1 +/- .5) * 600 us */
+	{ AO_MF_IR_DEC_LDR_IDLE,   45 << 16 | 15 << 0		    },
+	/* No repeat code */
+	{ AO_MF_IR_DEC_LDR_REPEAT, 0				    },
+	/* (2 +/- .5) * 600 us */
+	{ AO_MF_IR_DEC_BIT_0,	   75 << 16 | 45 << 0		    },
+	/*
+	 * Filter: 140 us, max frame time: (4.5 + 1.5 + 20 * 3.5) * 600 us,
+	 * base time: 20 us
+	 */
+	{ AO_MF_IR_DEC_REG0,	   7 << 28 | 2280 << 12 | (20 - 1)  },
+	/* Logic "1": (3 +/- .5) * 600 us */
+	{ AO_MF_IR_DEC_STATUS,	   1 << 30 | 105 << 20 | 75 << 10   },
+	/*
+	 * Reset the decoder as a workaround for an IP erratum causing the
+	 * repeat max frame interval in REG3 to be ignored for SIRC.
+	 */
+	{ AO_MF_IR_DEC_REG1,	   1 << 15 | (19 - 1) << 8 | 1	    },
+	/* Decoder, frame body limited to 19 bits because of IP erratum */
+	{ AO_MF_IR_DEC_REG1,	   1 << 15 | (19 - 1) << 8	    },
+	/* Check repeat time, compare frames for repeat, lsb first, Sony SIRC */
+	{ AO_MF_IR_DEC_REG2,	   1 << 12 | 1 << 11 | 0 << 8 | 0x6 },
+	{ AO_MF_IR_DEC_DURATN2,	   0				    },
+	{ AO_MF_IR_DEC_DURATN3,	   0				    },
+	/* Repeat max frame interval: 50 ms */
+	{ AO_MF_IR_DEC_REG3,	   500				    },
+	{ CONFIG_END,		   0				    }
+};
+
 static const reg_remote *remoteregsTab[] = {
 	RDECODEMODE_NEC,
 	RDECODEMODE_DUOKAN,
 	RDECODEMODE_TOSHIBA,
 	RDECODEMODE_RCA,
 	RDECODEMODE_RC5,
+	RDECODEMODE_SONYSIRC12,
+	RDECODEMODE_SONYSIRC15,
+	RDECODEMODE_SONYSIRC20,
 };
 
 void setremotereg(const reg_remote * r)

--- a/board/amlogic/configs/gxl_p212_v1.h
+++ b/board/amlogic/configs/gxl_p212_v1.h
@@ -77,7 +77,7 @@
 //#define CONFIG_IR_REMOTE
 //#define CONFIG_AML_IRDETECT_EARLY
 #define CONFIG_IR_REMOTE_POWER_UP_KEY_CNT 4
-#define CONFIG_IR_REMOTE_USE_PROTOCOL 0         // 0:nec  1:duokan  2:Toshiba 3:rca 4:rcmm
+#define CONFIG_IR_REMOTE_USE_PROTOCOL 0         // 0:nec  1:duokan  2:Toshiba 3:rca 4:rcmm 5:sirc12 6:sirc15 7:sirc20
 #define CONFIG_IR_REMOTE_POWER_UP_KEY_VAL1 0XE51AFB04 //amlogic tv ir --- power
 #define CONFIG_IR_REMOTE_POWER_UP_KEY_VAL2 0Xffffffff //amlogic tv ir --- ch+
 #define CONFIG_IR_REMOTE_POWER_UP_KEY_VAL3 0xffffffff //amlogic tv ir --- ch-

--- a/board/amlogic/configs/gxl_p241_v1.h
+++ b/board/amlogic/configs/gxl_p241_v1.h
@@ -74,7 +74,7 @@
 //#define CONFIG_IR_REMOTE
 //#define CONFIG_AML_IRDETECT_EARLY
 #define CONFIG_IR_REMOTE_POWER_UP_KEY_CNT 4
-#define CONFIG_IR_REMOTE_USE_PROTOCOL 0         // 0:nec  1:duokan  2:Toshiba 3:rca 4:rcmm
+#define CONFIG_IR_REMOTE_USE_PROTOCOL 0         // 0:nec  1:duokan  2:Toshiba 3:rca 4:rcmm 5:sirc12 6:sirc15 7:sirc20
 #define CONFIG_IR_REMOTE_POWER_UP_KEY_VAL1 0XE51AFB04 //amlogic tv ir --- power
 #define CONFIG_IR_REMOTE_POWER_UP_KEY_VAL2 0Xffffffff //amlogic tv ir --- ch+
 #define CONFIG_IR_REMOTE_POWER_UP_KEY_VAL3 0xffffffff //amlogic tv ir --- ch-

--- a/board/amlogic/configs/gxl_p400_v1.h
+++ b/board/amlogic/configs/gxl_p400_v1.h
@@ -71,7 +71,7 @@
 //#define CONFIG_IR_REMOTE
 //#define CONFIG_AML_IRDETECT_EARLY
 #define CONFIG_IR_REMOTE_POWER_UP_KEY_CNT 4
-#define CONFIG_IR_REMOTE_USE_PROTOCOL 0         // 0:nec  1:duokan  2:Toshiba 3:rca 4:rcmm
+#define CONFIG_IR_REMOTE_USE_PROTOCOL 0         // 0:nec  1:duokan  2:Toshiba 3:rca 4:rcmm 5:sirc12 6:sirc15 7:sirc20
 #define CONFIG_IR_REMOTE_POWER_UP_KEY_VAL1 0XE51AFB04 //amlogic tv ir --- power
 #define CONFIG_IR_REMOTE_POWER_UP_KEY_VAL2 0Xffffffff //amlogic tv ir --- ch+
 #define CONFIG_IR_REMOTE_POWER_UP_KEY_VAL3 0xffffffff //amlogic tv ir --- ch-

--- a/board/amlogic/configs/gxl_p401_v1.h
+++ b/board/amlogic/configs/gxl_p401_v1.h
@@ -71,7 +71,7 @@
 //#define CONFIG_IR_REMOTE
 //#define CONFIG_AML_IRDETECT_EARLY
 #define CONFIG_IR_REMOTE_POWER_UP_KEY_CNT 4
-#define CONFIG_IR_REMOTE_USE_PROTOCOL 0         // 0:nec  1:duokan  2:Toshiba 3:rca 4:rcmm
+#define CONFIG_IR_REMOTE_USE_PROTOCOL 0         // 0:nec  1:duokan  2:Toshiba 3:rca 4:rcmm 5:sirc12 6:sirc15 7:sirc20
 #define CONFIG_IR_REMOTE_POWER_UP_KEY_VAL1 0XE51AFB04 //amlogic tv ir --- power
 #define CONFIG_IR_REMOTE_POWER_UP_KEY_VAL2 0Xffffffff //amlogic tv ir --- ch+
 #define CONFIG_IR_REMOTE_POWER_UP_KEY_VAL3 0xffffffff //amlogic tv ir --- ch-

--- a/board/amlogic/configs/gxl_skt_v1.h
+++ b/board/amlogic/configs/gxl_skt_v1.h
@@ -64,7 +64,7 @@
 
 //Enable ir remote wake up for bl30
 
-#define CONFIG_IR_REMOTE_USE_PROTOCOL 4         // 0:nec 1:duokan 2:Toshiba 3:rca 4:rc5
+#define CONFIG_IR_REMOTE_USE_PROTOCOL 4         // 0:nec 1:duokan 2:Toshiba 3:rca 4:rc5 5:sirc12 6:sirc15 7:sirc20
 #define CONFIG_IR_REMOTE_POWER_UP_KEY_CNT 3
 #define CONFIG_IR_REMOTE_POWER_UP_KEY_VAL1 0XE51AFB04 //amlogic tv ir --- power
 #define CONFIG_IR_REMOTE_POWER_UP_KEY_VAL2 0Xffffffff //amlogic tv ir --- ch+

--- a/board/khadas/configs/kvim.h
+++ b/board/khadas/configs/kvim.h
@@ -76,7 +76,7 @@
 //#define CONFIG_IR_REMOTE
 //#define CONFIG_AML_IRDETECT_EARLY
 #define CONFIG_IR_REMOTE_POWER_UP_KEY_CNT 4
-#define CONFIG_IR_REMOTE_USE_PROTOCOL 0         // 0:nec  1:duokan  2:Toshiba 3:rca 4:rcmm
+#define CONFIG_IR_REMOTE_USE_PROTOCOL 0         // 0:nec  1:duokan  2:Toshiba 3:rca 4:rcmm 5:sirc12 6:sirc15 7:sirc20
 #define CONFIG_IR_REMOTE_POWER_UP_KEY_VAL1 0XEB14FF00 //amlogic tv ir --- power
 #define CONFIG_IR_REMOTE_POWER_UP_KEY_VAL2 0Xffffffff //amlogic tv ir --- ch+
 #define CONFIG_IR_REMOTE_POWER_UP_KEY_VAL3 0xffffffff //amlogic tv ir --- ch-

--- a/board/khadas/configs/kvim2.h
+++ b/board/khadas/configs/kvim2.h
@@ -74,7 +74,7 @@
 //#define CONFIG_IR_REMOTE
 //#define CONFIG_AML_IRDETECT_EARLY
 #define CONFIG_IR_REMOTE_POWER_UP_KEY_CNT 4
-#define CONFIG_IR_REMOTE_USE_PROTOCOL 0         // 0:nec  1:duokan  2:Toshiba 3:rca 4:rcmm
+#define CONFIG_IR_REMOTE_USE_PROTOCOL 0         // 0:nec  1:duokan  2:Toshiba 3:rca 4:rcmm 5:sirc12 6:sirc15 7:sirc20
 #define CONFIG_IR_REMOTE_POWER_UP_KEY_VAL1 0XEB14FF00 //amlogic tv ir --- power
 #define CONFIG_IR_REMOTE_POWER_UP_KEY_VAL2 0Xffffffff //amlogic tv ir --- ch+
 #define CONFIG_IR_REMOTE_POWER_UP_KEY_VAL3 0xffffffff //amlogic tv ir --- ch-


### PR DESCRIPTION
Contrary to most IR RC protocols, the Sony SIRC frames end with a data
bit, not with a trailer pulse, which triggers the following bugs in the
hardware IR decoder because it relies on pulse intervals instead of
pulse widths:

 - The last data bit (msb) cannot be read properly. It can only be
   dropped, in which case it is always returned as 0, or forcibly read
   by using an abnormally long maximum frame duration and ignoring the
   logic 1 timings, in which case it is stuck to 1. This implementation
   chooses to drop the msb because it is part of the device ID, so this
   limitation is very unlikely to cause any trouble.

 - The repeat maximum frame interval in AO_MF_IR_DEC_REG3 is ignored.
   Consequently, if the same RC key is pressed twice in a row, the
   decoder reports the second key press as a repeat event, even if there
   is a very long time between the key presses. This implementation
   works around this bug by resetting the decoder during its
   initialization. Since the decoder is always initialized right before
   waiting for a key press, there should be no issue.

In order to support the SIRC protocol without any limitation, a software
decoder would have to be used with the general time measurement mode.