### PR TITLE
kvim3: remove CONFIG_SYS_MEM_TOP_HIDE

### DIFF
--- a/board/khadas/configs/kvim3.h
+++ b/board/khadas/configs/kvim3.h
@@ -648,7 +648,7 @@
 #define CONFIG_CMD_MISC     1
 #define CONFIG_CMD_ITEST    1
 #define CONFIG_CMD_CPU_TEMP 1
-#define CONFIG_SYS_MEM_TOP_HIDE 0x08000000 //hide 128MB for kernel reserve
+#define CONFIG_SYS_MEM_TOP_HIDE 0
 #define CONFIG_CMD_LOADB    1
 
 


### PR DESCRIPTION
Normally this would be ignored if memory is defined in the device-tree,
however on KVIM3 the memory node has been removed and so users lose
128MB that this config option is taking up, needed memory is already
reserved by the linux kernel.