### PR TITLE
Fix 16 bit address byte order for i2c transactions

### DIFF
--- a/drivers/i2c/aml_i2c.c
+++ b/drivers/i2c/aml_i2c.c
@@ -721,8 +721,9 @@ int i2c_read(uchar chip, uint addr, int alen, uchar *buffer, int len)
 			   else
 #endif
 			   {
-					devaddr[0] = addr & 0xff;
-					devaddr[1] = (addr >> 8) & 0xff;
+				   	// devices like EEPROMS send [high byte] [low byte] for 16 bit addresses
+					devaddr[0] = (addr >> 8) & 0xff;
+					devaddr[1] = addr & 0xff;
 			   }
 			   break;
 
@@ -811,8 +812,9 @@ int i2c_write(unsigned char chip, unsigned int addr, int alen,unsigned char *buf
 			else
 #endif
 			   {
-					devaddr[0] = addr & 0xff;
-					devaddr[1] = (addr >> 8) & 0xff;
+					// devices like EEPROMS send [high byte] [low byte] for 16 bit addresses
+					devaddr[0] = (addr >> 8) & 0xff; 
+					devaddr[1] = addr & 0xff;
 			   }
 			   break;
 


### PR DESCRIPTION
# Why the change?

When setting the read/write pointer for an EEPROM that uses 16 bit addressing to access the internal memory, the bytes are sent [high byte] [low byte].  This commit fixes the byte ordering when sending the address to the device.

# Problem example

I used an I2C EEPROM with 16 bit addressing and stored a string into the memory for recall within u-boot.  Here is the information stored in the eeprom, and being read out again from within linux to show that is stored correctly:

![image](https://user-images.githubusercontent.com/37915589/127430337-f7932b19-d476-4475-82b5-770a5e0b8a94.png)

![image](https://user-images.githubusercontent.com/37915589/127430354-378a46b8-ac76-4c33-ad0b-3ba3d007cce6.png)

**_but, when I read it from u-boot, the data was incorrect_**

![image](https://user-images.githubusercontent.com/37915589/127430406-624e410f-efd1-48e2-95ec-672e693e98ce.png)

using an i2c protocol analyzer to observe the transaction showed the problem.  The code is reading 16 bytes at a time, and setting the address after each read of 16 bytes.  The address is incorrect (high and low bytes are swapped)

![image](https://user-images.githubusercontent.com/37915589/127430453-d0b450c6-e500-47cd-b7ad-e98736b05a36.png)

![image](https://user-images.githubusercontent.com/37915589/127430467-dd7f3106-aee5-4b37-b529-ed7f69ba215d.png)

I can further illustrate the problem by forcing the swap of the bytes manually in the command

![image](https://user-images.githubusercontent.com/37915589/127430557-dddd1821-4164-4e94-9e29-f6f112830cba.png)

# The fix

As shown in the code, the fix is to properly send the address when doing a read or a write.  After making the change, the data can be read correctly from the i2c device.

![image](https://user-images.githubusercontent.com/37915589/127430691-b3322df4-259e-421b-a17e-6667c339d292.png)
