### PR TITLE
Remove redundant YYLOC global declaration

### DIFF
--- a/scripts/dtc/dtc-lexer.l
+++ b/scripts/dtc/dtc-lexer.l
@@ -38,7 +38,6 @@ LINECOMMENT	"//".*\n
 #include "srcpos.h"
 #include "dtc-parser.tab.h"
 
-YYLTYPE yylloc;
 extern bool treesource_error;
 
 /* CAUTION: this will stop working if we ever use yyless() or yyunput() */


### PR DESCRIPTION
Same as the upstream fix for building dtc with gcc 10.

Signed-off-by: Peter Robinson <pbrobinson@gmail.com>

Backport from:
  https://github.com/u-boot/u-boot/commit/018921ee79d3f30893614b3b2b63b588d8544f73

Happens with some newer versions of GCC.

Fixes:
```
  CHK     include/config.h
  CFG     u-boot.cfg
  HOSTCC  scripts/dtc/dtc-parser.tab.o
  HOSTCC  scripts/dtc/dtc-lexer.lex.o
  HOSTLD  scripts/dtc/dtc
/usr/bin/ld: scripts/dtc/dtc-parser.tab.o:(.bss+0x10): multiple definition of `yylloc'; scripts/dtc/dtc-lexer.lex.o:(.bss+0x0): first defined here
collect2: error: ld returned 1 exit status
make[3]: *** [scripts/Makefile.host:106: scripts/dtc/dtc] Error 1
make[2]: *** [../scripts/Makefile.build:434: scripts/dtc] Error 2
make[1]: *** [/home/aardelean/work/portable/android/bootloader/uboot/Makefile:525: scripts] Error 2
make[1]: *** Waiting for unfinished jobs....
  UPD     include/config/acs.release
  UPD     include/config/uboot.release
make[1]: Leaving directory '/home/aardelean/work/portable/android/bootloader/uboot/build'
make: *** [Makefile:150: sub-make] Error 2
```