### PR TITLE
Fix intermittent crc errors when booting from sdcard

### DIFF
--- a/drivers/mmc/mmc.c
+++ b/drivers/mmc/mmc.c
@@ -1722,9 +1722,9 @@ static const struct mode_width_tuning sd_modes_by_pref[] = {
 	{
 		.mode = SD_HS,
 		.widths = MMC_MODE_4BIT | MMC_MODE_1BIT,
-#ifdef MMC_SUPPORTS_TUNING
-		.tuning = MMC_SD_HS_TUNING
-#endif
+//#ifdef MMC_SUPPORTS_TUNING
+//		.tuning = MMC_SD_HS_TUNING
+//#endif
 	},
 #if CONFIG_IS_ENABLED(MMC_UHS_SUPPORT)
 	{


### PR DESCRIPTION
When booting from UHS-I cards on VIM4 and VIM1S, mine was Samsung EVO Plus card (MB-MC64KA), booting only worked 1 out of 5 reboots. Other times the device either tried booting from EMMC or from SPI flash. As this use to work fine in 1.5.2 release, I tried to go through the code to pinpoint the issue. I also confirmed the issue using git bisect which brought me to [bfa451f](https://github.com/khadas/u-boot/commit/bfa451f799eac8a69d4e58a32af7b00bec012e1d) commit and reverting the same solves the issue. VIM4 now boots reliably from SD card every time I restart the same.