### PR TITLE
Remove 2560x1080p60hz from supported modes

### DIFF
--- a/cmd/amlogic/edid-decode.c
+++ b/cmd/amlogic/edid-decode.c
@@ -161,10 +161,8 @@ static const char *khadas_support_modes[] = {
 	"1600x1200p60hz",
 	"1680x1050p60hz",
 	"1920x1200p60hz",
-	"2560x1080p60hz",
 	"2560x1440p60hz",
 	"2560x1600p60hz",
-	"2560x1080p60hz",
 };
 
 static void


### PR DESCRIPTION
I have a widescreen LG monitor with `2560x1080p60hz` resolution support. On vim1s/vim4, the monitor just gets stuck on khadas logo for server image. For desktop image, once gnome starts, gnome switches the resolution to 1920x1080p60hz and monitor is able to work with the same.

When comparing the dmesg outputs from a standard 1920x1080 monitor vs my widescreen monitor, I noticed that dmesg was missing logs that shows drm has found the matching connector. Checking `/sys/class/drm/card0-HDMI-A-1/modes` also doesn't list the 2560x1080p60hz.

Hence removing the resolution from u-boot, so that we can boot with lower resolution with a working monitor. if 2560x1080p60hz mode really works on some monitor, Gnome should be able to automatically choose the same or user can use it using the Gnome's desktop settings.