### PR TITLE
Bring back 2560x1080p60hz support for HDMI 1.4 compliant monitors

### DIFF
--- a/cmd/amlogic/edid-decode.c
+++ b/cmd/amlogic/edid-decode.c
@@ -161,6 +161,7 @@ static const char *khadas_support_modes[] = {
 	"1600x1200p60hz",
 	"1680x1050p60hz",
 	"1920x1200p60hz",
+	"2560x1080p60hz",
 	"2560x1440p60hz",
 	"2560x1600p60hz",
 };
@@ -638,6 +639,18 @@ detailed_block(unsigned char *x, int in_extension)
 		phsync, pvsync, syncmethod, x[17] & 0x80 ? " interlaced" : "",
 		stereo
 	);
+
+	/*
+	 * For HDMI 1.x displays, the kernel edid parsing code from amlogic relies on max tmds information being availble
+	 * otherwise it limits the maximum pclk to be HDMI 1.0 range making it skip any higher clock modes.
+	 * Lets do the same here as well so that we would choose a working resolution
+	 */
+	if (claims_one_point_oh && !claims_one_point_four) {
+		if (((x[0] + (x[1] << 8)) / 100) > 165 ) {
+			printf("Skipping detailed mode %4dx%4d as its not supported by the kernel\n", ha, va);
+			return 1;
+		}
+	}
 
 	/* detailed timings in extension block will be excluded
 	 * from candidates to find the best mode.


### PR DESCRIPTION
Bring back 2560x1080p60hz resolution but restrict it for HDMI 1.4 compliant monitors


The Amlogic kernel's EDID parsing code restricts TMDS clock to be 165Mhz for HDMI 1.x monitors that doesn't support HDMI 1.4 specification specifically they don't provide `Maximum TMDS frequency`  value in the `Vendor Specific Data Block`. HDMI 1.3 is supposed to get this value using `Maximum pixel clock rate` field of `Display Range Limits Descriptor` block, but kernel EDID parsing code doesn't parse the same.

This becomes a problem as 2560x1080p60hz mode requires TMDS clock of 185Mhz or higher but because of the limitation, kernel marks it as invalid mode and we end up with a non working monitor. Hence added similar restriction when parsing the EDID in u-boot to make sure we will get modes that we can display on the monitor.