### PR TITLE
VIM4: null pointer problem

### DIFF
--- a/cmd/amlogic/cmd_hdmitx21.c
+++ b/cmd/amlogic/cmd_hdmitx21.c
@@ -1324,7 +1324,8 @@ static int do_get_parse_edid(cmd_tbl_t *cmdtp, int flag, int argc, char *const a
 	 */
 	if (get_hdr_policy() == 1)
 		env_set("dolby_status", 0);
-	hdev->para = hdmitx21_get_fmtpara(sel_hdmimode, env_get("colorattribute"));
+	if (hdmitx21_get_fmtpara(sel_hdmimode, env_get("colorattribute")))
+		hdev->para = hdmitx21_get_fmtpara(sel_hdmimode, env_get("colorattribute"));
 	hdev->vic = hdev->para->timing.vic;
 	hdmitx_mask_rx_info(hdev);
 	hdmitx21_select_frl(hdev);


### PR DESCRIPTION
When hdmi connect Raspberry Pi small screen

"Synchronous Abort" handler, esr 0x96000007
Fault address:0x20
elr: 0000000000039a24 lr : 0000000000039a20 (reloc) elr: 00000000dfd7ba24 lr : 00000000dfd7ba20
x0 : 0000000000000000 x1 : 0000000000003700
x2 : 00000000dfeb4908 x3 : 0000000000003700
x4 : 0000000000000000 x5 : 0000000000000316
x6 : 0000000000000000 x7 : 0000000000000006
x8 : 00000000dffd2f20 x9 : 0000000000000008
x10: fffffffffffffffd x11: 0000000000000000
x12: 0000000000000000 x13: ffffff0000000000
x14: 0ffffffffffffffe x15: 30323178555c565f
x16: 00000000000010a0 x17: 00000000ff00e140
x18: 00000000d9d315c0 x19: 00000000dffd2f20
x20: 00000000dfedf369 x21: 0000000000000000
x22: 00000000dffb38f0 x23: 0000000000000000
x24: 0000000000000001 x25: 00000000d9e4df50
x26: 0000000000000000 x27: 00000000dffd3ec9
x28: 00000000d97ff228 x29: 00000000d97ff130

Call trace:
[<00000000dfd7ba24>] do_get_parse_edid+0x658/0x778 [<00000000dfdacbf4>] cmd_process+0xf4/0x19c
[<00000000dfd9d03c>] run_list_real+0x6f0/0x724
[<00000000dfd9d1f8>] parse_stream_outer+0x188/0x6bc [<00000000dfd9c8d4>] parse_string_outer+0xa0/0x118 [<00000000dfdabff4>] run_command+0x34/0x78
[<00000000dfdac128>] do_run+0x54/0x80
[<00000000dfdacbf4>] cmd_process+0xf4/0x19c
[<00000000dfd9d03c>] run_list_real+0x6f0/0x724
[<00000000dfd9d1f8>] parse_stream_outer+0x188/0x6bc [<00000000dfd9c8d4>] parse_string_outer+0xa0/0x118 [<00000000dfdabff4>] run_command+0x34/0x78
[<00000000dfdac128>] do_run+0x54/0x80
[<00000000dfdacbf4>] cmd_process+0xf4/0x19c
[<00000000dfd9d03c>] run_list_real+0x6f0/0x724
[<00000000dfd9ccb4>] run_list_real+0x368/0x724
[<00000000dfd9ccb4>] run_list_real+0x368/0x724
[<00000000dfd9ccb4>] run_list_real+0x368/0x724
[<00000000dfd9d1f8>] parse_stream_outer+0x188/0x6bc [<00000000dfd9c8d4>] parse_string_outer+0xa0/0x118 [<00000000dfdabff4>] run_command+0x34/0x78
[<00000000dfdac128>] do_run+0x54/0x80
[<00000000dfdacbf4>] cmd_process+0xf4/0x19c
[<00000000dfd9d03c>] run_list_real+0x6f0/0x724
[<00000000dfd9d1f8>] parse_stream_outer+0x188/0x6bc [<00000000dfd9c8d4>] parse_string_outer+0xa0/0x118 [<00000000dfdac090>] run_command_list+0x58/0x9c
[<00000000dfd9b23c>] main_loop+0x54/0x9c
[<00000000dfd9e910>] run_main_loop+0x8/0x10
[<00000000dfe902cc>] initcall_run_list+0x54/0xec
[<00000000dfd9ebf8>] board_init_r+0x1c/0x24


Change-Id: I3367e5d2333ebb92a3172d321a43c34bfe3781e2