### PR TITLE
VIM3/3l: Fixed booting from fat partition from sdcard

### DIFF
--- a/drivers/usb/gadget/v2_burning/aml_v2_burning.c
+++ b/drivers/usb/gadget/v2_burning/aml_v2_burning.c
@@ -48,10 +48,10 @@ int aml_check_is_ready_for_sdc_produce(void)
         setenv("sdcburncfg", sdc_cfg_file);
     }
 
-	cmd = "fatload mmc 0 $loadaddr ${sdcburncfg} 64";
+    cmd = "fatload mmc 0 $loadaddr ${sdcburncfg} 64";
     ret = run_command(cmd, 0);
     filesize = getenv("filesize");
-    if (NULL == filesize || strcmp(filesize, "0") == 0) {
+    if (ret || NULL == filesize || strcmp(filesize, "0") == 0) {
         DWN_DBG("%s not exist\n", sdc_cfg_file);
         return 0;
     }


### PR DESCRIPTION
The check for verifying if sdc_cfg_file exists was based on filesize. But its possible that filesize might already be set because of us loading the dtb file. Hence we also need to check if the fatload command was successful