### PR TITLE
VIM3/3L:fix booting from fat partition from EMMC

### DIFF
--- a/drivers/mmc/mmc.c
+++ b/drivers/mmc/mmc.c
@@ -74,7 +74,7 @@ bool emmckey_is_access_range_legal (struct mmc *mmc, ulong start, lbaint_t blkcn
 #else
 		key_end_blk = ((key_glb_offset + vpart->size) / MMC_BLOCK_SIZE - 1);
 #endif
-		if (!(info_disprotect & DISPROTECT_KEY)) {
+		if (!(info_disprotect & DISPROTECT_KEY) && (is_partition_checked == true)) {
 			if ((key_start_blk <= (start + blkcnt -1))
 				&& (key_end_blk >= start)
 				&& (blkcnt != start)) {


### PR DESCRIPTION
Regarrding emmc fat partition fix, we had this change in khadas-vims-v2015.01 branch, but it seems we missed to add this to khadas-vims-v2015.01-5.15 branch. Without this change, we fail to boot from fat partition on emmc.
